### PR TITLE
Avoid 'upload' terminology

### DIFF
--- a/cmd/worker/worker.go
+++ b/cmd/worker/worker.go
@@ -82,7 +82,7 @@ func (c *Command) entrypoint(ctx context.Context, args []string) error {
 	}
 
 	if err := c.loop(ctx); err != nil {
-		return fmt.Errorf("upload handler loop: %w", err)
+		return fmt.Errorf("tunnel handler loop: %w", err)
 	}
 
 	return nil


### PR DESCRIPTION
Did a quick scan of the codebase and this is the only place I found we're still using the 'upload' terminology. The loop in question is now handling tunnels, not uploads.