### PR TITLE
version: add subcommand to print build info

### DIFF
--- a/cmd/run/run.go
+++ b/cmd/run/run.go
@@ -31,6 +31,7 @@ import (
 	"subtrace.dev/cmd/run/kernel"
 	"subtrace.dev/cmd/run/tls"
 	"subtrace.dev/cmd/run/tracer"
+	"subtrace.dev/cmd/version"
 	"subtrace.dev/logging"
 )
 
@@ -105,6 +106,8 @@ func (c *Command) entrypoint(ctx context.Context, args []string) error {
 	if val := os.Getenv("SUBTRACE_TOKEN"); val == "" {
 		return fmt.Errorf("SUBTRACE_TOKEN is empty")
 	}
+
+	slog.Info("starting tracer", "version", version.Version, slog.Group("commit", "hash", version.CommitHash, "time", version.CommitTime), "build", version.BuildTime)
 
 	switch os.Getenv("_SUBTRACE_CHILD") {
 	case "": // parent
@@ -248,7 +251,7 @@ func (c *Command) entrypointParent(ctx context.Context, args []string) (int, err
 		return 0, fmt.Errorf("ensure asyncpreemptoff=1: %w", err)
 	}
 
-	slog.Debug("starting subtrace parent", "pid", os.Getpid())
+	slog.Debug("starting tracer parent", "pid", os.Getpid())
 
 	if _, _, err := kernel.CheckVersion(minKernelVersion, true); err != nil {
 		return 0, fmt.Errorf("check kernel version: %w", err)

--- a/cmd/version/version.go
+++ b/cmd/version/version.go
@@ -1,0 +1,36 @@
+package version
+
+import (
+	"context"
+	"fmt"
+	"runtime"
+
+	"github.com/peterbourgon/ff/v3/ffcli"
+)
+
+var (
+	Version    = "unknown"
+	CommitHash = "unknown"
+	CommitTime = "unknown"
+	BuildTime  = "unknown"
+)
+
+type Command struct {
+	ffcli.Command
+}
+
+func NewCommand() *ffcli.Command {
+	c := new(Command)
+
+	c.Name = "version"
+	c.ShortUsage = "subtrace version"
+	c.ShortHelp = "print subtrace version"
+
+	c.Exec = c.entrypoint
+	return &c.Command
+}
+
+func (c *Command) entrypoint(ctx context.Context, args []string) error {
+	fmt.Printf("subtrace version %s (%s) %s %s/%s\n", Version, CommitHash, runtime.Version(), runtime.GOOS, runtime.GOARCH)
+	return nil
+}

--- a/cmd/worker/worker.go
+++ b/cmd/worker/worker.go
@@ -27,6 +27,7 @@ import (
 	"github.com/peterbourgon/ff/v3/ffcli"
 	"google.golang.org/protobuf/proto"
 	"nhooyr.io/websocket"
+	"subtrace.dev/cmd/version"
 	"subtrace.dev/cmd/worker/clickhouse"
 	"subtrace.dev/event"
 	"subtrace.dev/logging"
@@ -73,7 +74,7 @@ func (c *Command) entrypoint(ctx context.Context, args []string) error {
 		return fmt.Errorf("SUBTRACE_TOKEN is empty")
 	}
 
-	slog.Info("starting worker node")
+	slog.Info("starting worker node", "version", version.Version, slog.Group("commit", "hash", version.CommitHash, "time", version.CommitTime), "build", version.BuildTime)
 
 	if err := c.initClickhouse(ctx); err != nil {
 		return fmt.Errorf("init clickhouse: %w", err)

--- a/make.sh
+++ b/make.sh
@@ -3,7 +3,21 @@
 set -eo pipefail
 
 cmd:subtrace() {
-  CGO_ENABLED=0 go build -o subtrace
+  SUBTRACE_RELEASE_VERSION=$(printf "b%03d" "$(git log --oneline | wc -l)")
+  SUBTRACE_COMMIT_HASH="$(git log -1 --format='%H' 2>/dev/null || echo unknown)"
+  SUBTRACE_COMMIT_TIME=$(TZ=UTC git log -1 --date='format-local:%Y-%m-%dT%H:%M:%SZ' --format='%cd' 2>/dev/null || echo unknown)
+  SUBTRACE_BUILD_TIME="${SOURCE_DATE_EPOCH}"
+  if [[ "${SUBTRACE_BUILD_TIME}" == "" ]]; then
+    SUBTRACE_BUILD_TIME=$(TZ=UTC date '+%Y-%m-%dT%H:%M:%SZ')
+  fi
+
+  LDFLAGS=
+  LDFLAGS="${LDFLAGS} -X subtrace.dev/cmd/version.Version=${SUBTRACE_RELEASE_VERSION}"
+  LDFLAGS="${LDFLAGS} -X subtrace.dev/cmd/version.CommitHash=${SUBTRACE_COMMIT_HASH}"
+  LDFLAGS="${LDFLAGS} -X subtrace.dev/cmd/version.CommitTime=${SUBTRACE_COMMIT_TIME}"
+  LDFLAGS="${LDFLAGS} -X subtrace.dev/cmd/version.BuildTime=${SUBTRACE_BUILD_TIME}"
+
+  CGO_ENABLED=0 go build -ldflags "${LDFLAGS}" -o subtrace
 }
 
 cmd:proto() {

--- a/subtrace.go
+++ b/subtrace.go
@@ -15,6 +15,7 @@ import (
 	"github.com/peterbourgon/ff/v3/ffcli"
 	"subtrace.dev/cmd/run"
 	"subtrace.dev/cmd/worker"
+	"subtrace.dev/cmd/version"
 )
 
 func main() {
@@ -27,6 +28,7 @@ func main() {
 
 	c.Subcommands = append(c.Subcommands, run.NewCommand())
 	c.Subcommands = append(c.Subcommands, worker.NewCommand())
+	c.Subcommands = append(c.Subcommands, version.NewCommand())
 
 	c.FlagSet = flag.NewFlagSet("subtrace", flag.ContinueOnError)
 	c.FlagSet.SetOutput(os.Stdout)


### PR DESCRIPTION
Example:

```
$ subtrace version
subtrace version b043 (8cbc5aed9d6bb507387232bf1248cb24329d2984) go1.22.1 linux/arm64
```

```
$ subtrace run -v -- ls
time=2024-08-20T19:07:42.467-04:00 level=INFO src=cmd/run/run.go:110 msg="starting tracer" version=b044 commit.hash=0290160b9642461d07f3bfcd57d68e97ea34a681 commit.time=2024-08-20T23:06:59Z build=2024-08-20T23:07:40Z
...
```

Very useful for when we need to debug problems remotely.