### PR TITLE
worker.Dockerfile: use clickhouse/clickhouse-server as base

### DIFF
--- a/worker.Dockerfile
+++ b/worker.Dockerfile
@@ -3,20 +3,8 @@ WORKDIR /go/src/subtrace
 COPY . .
 RUN --mount=type=cache,target=/go/pkg --mount=type=cache,target=/root/.cache make
 
-FROM debian:12
-
-RUN apt-get update && apt-get install -y ca-certificates curl
-
-ARG TARGETARCH
-RUN cat | bash - <<EOF
-  curl -sLO "https://packages.clickhouse.com/deb/pool/main/c/clickhouse/clickhouse-common-static_23.12.6.19_${TARGETARCH}.deb"
-  curl -sLO "https://packages.clickhouse.com/deb/pool/main/c/clickhouse/clickhouse-server_23.12.6.19_${TARGETARCH}.deb"
-  DEBIAN_FRONTEND=noninteractive apt install -y ./clickhouse-common-static_23.12.6.19_${TARGETARCH}.deb ./clickhouse-server_23.12.6.19_${TARGETARCH}.deb
-  rm ./clickhouse-common-static_23.12.6.19_${TARGETARCH}.deb ./clickhouse-server_23.12.6.19_${TARGETARCH}.deb
-EOF
-
+FROM clickhouse/clickhouse-server:24.8-alpine
 COPY --from=build /go/src/subtrace/subtrace /usr/local/bin/subtrace
-
 RUN cat >/usr/local/bin/start_worker.sh <<EOF
   clickhouse-server &
   export SUBTRACE_CLICKHOUSE_HOST=localhost
@@ -24,5 +12,4 @@ RUN cat >/usr/local/bin/start_worker.sh <<EOF
   export SUBTRACE_CLICKHOUSE_FORMAT_SCHEMAS=/var/lib/clickhouse/format_schemas
   subtrace worker \$*
 EOF
-
 ENTRYPOINT ["/usr/bin/bash", "/usr/local/bin/start_worker.sh"]


### PR DESCRIPTION
This greatly reduces build time (from 2-3 minutes to ~10 seconds) and image size (from ~1.4 GiB to ~600 MiB).

Also upgrades clickhouse-server to 24.8 (LTS).