### PR TITLE
go: upgrade go to 1.24.2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.24.1 AS build
+FROM golang:1.24.2 AS build
 WORKDIR /go/src/subtrace
 COPY . .
 RUN --mount=type=cache,target=/go/pkg --mount=type=cache,target=/root/.cache make

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module subtrace.dev
 
-go 1.24.1
+go 1.24.2
 
 require (
 	github.com/ClickHouse/clickhouse-go/v2 v2.30.0

--- a/worker.Dockerfile
+++ b/worker.Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=$BUILDPLATFORM golang:1.24.1 AS build
+FROM --platform=$BUILDPLATFORM golang:1.24.2 AS build
 WORKDIR /go/src/subtrace
 COPY . .
 ARG TARGETARCH


### PR DESCRIPTION
Upgrading to golang 1.24.2 to address this vulnerability: https://nvd.nist.gov/vuln/detail/CVE-2025-22871

This shows up when scanning the golang image for vulnerabilities