### PR TITLE
etc: remove deprecated license classifier in python package setup

### DIFF
--- a/etc/python/setup.py
+++ b/etc/python/setup.py
@@ -24,7 +24,6 @@ setup(
     ],
 
     classifiers=[
-        "License :: OSI Approved :: BSD License",
         "Programming Language :: Python",
         "Programming Language :: Python :: 2",
         "Programming Language :: Python :: 3",


### PR DESCRIPTION
Fixes this build warning:

/tmp/build-env-t6g8him8/lib/python3.12/site-packages/setuptools/dist.py:759: SetuptoolsDeprecationWarning: License classifiers are deprecated.
!!

        ********************************************************************************
        Please consider removing the following classifiers in favor of a SPDX license expression:

        License :: OSI Approved :: BSD License

        See https://packaging.python.org/en/latest/guides/writing-pyproject-toml/#license for details.
        ********************************************************************************

!!