### PR TITLE
worker: remove websocket read limit

### DIFF
--- a/cmd/worker/worker.go
+++ b/cmd/worker/worker.go
@@ -299,7 +299,7 @@ func (c *Command) newTunnelConn(ctx context.Context, tunnelID uuid.UUID, endpoin
 		return nil, err
 	}
 
-	conn.SetReadLimit(64 << 20)
+	conn.SetReadLimit(-1)
 
 	tc.websocket = conn
 	return tc, nil


### PR DESCRIPTION
We're seeing errors around failing to flush blocks because the read limit is hit. Currently it's 64 MB, and the largest block I saw in the last 14 days is ~289 MB.