### PR TITLE
docs: remove duplicate 'documentation' section

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -85,11 +85,6 @@
           "icon": "table"
         },
         {
-          "anchor": "Documentation",
-          "href": "https://subtrace.dev/docs",
-          "icon": "book-open-cover"
-        },
-        {
           "anchor": "Discord",
           "href": "https://subtrace.dev/discord",
           "icon": "discord"


### PR DESCRIPTION
The "documentation" section is duplicated, once as a heading and once as an item in the list:

<img width="312" height="259" alt="Screenshot 2025-09-22 at 5 20 14 PM" src="https://github.com/user-attachments/assets/b381b1ae-6456-4697-8162-9327a017789b" />
